### PR TITLE
add downloading packages from bioconductor

### DIFF
--- a/hands-on.Rmd
+++ b/hands-on.Rmd
@@ -21,6 +21,17 @@ Now, you can open up`RStudio` and open up a new project for this module (`File >
 Let's start by loading the filtered data and the required libraries:
 ```{r load}
 
+# Install requested libraries from Bioconductor
+
+# try http:// if https:// URLs are not supported
+
+source("https://bioconductor.org/biocLite.R")
+biocLite("DESeq2")
+source("https://bioconductor.org/biocLite.R")
+biocLite("edgeR")
+source("https://bioconductor.org/biocLite.R")
+biocLite("limma")
+
 # Load required libraries 
 library(DESeq2)
 library(edgeR)


### PR DESCRIPTION
First time users of these packages frequently need to download them from bioconductor. The added lines will do that so library() commands work.
